### PR TITLE
Fixed incorrect error level checks

### DIFF
--- a/src/main/java/lanat/utils/errors/ErrorContainerImpl.java
+++ b/src/main/java/lanat/utils/errors/ErrorContainerImpl.java
@@ -72,8 +72,8 @@ public abstract class ErrorContainerImpl<T extends ErrorLevelProvider> implement
 	}
 
 	private <TErr extends ErrorLevelProvider> boolean errorIsInMinimumLevel(@NotNull TErr error, boolean isDisplayError) {
-		return (isDisplayError ? this.minimumDisplayErrorLevel : this.minimumExitErrorLevel).get()
-			.isInMinimum(error.getErrorLevel());
+		return error.getErrorLevel()
+			.isInMinimum((isDisplayError ? this.minimumDisplayErrorLevel : this.minimumExitErrorLevel).get());
 	}
 
 	protected <TErr extends ErrorLevelProvider> boolean anyErrorInMinimum(@NotNull List<TErr> errors, boolean isDisplayError) {

--- a/src/main/java/lanat/utils/errors/ErrorLevel.java
+++ b/src/main/java/lanat/utils/errors/ErrorLevel.java
@@ -8,10 +8,10 @@ import textFormatter.color.SimpleColor;
  * Represents the multiple levels that an error can have.
  */
 public enum ErrorLevel {
-	ERROR(SimpleColor.BRIGHT_RED),
-	WARNING(SimpleColor.BRIGHT_YELLOW),
+	DEBUG(SimpleColor.BRIGHT_GREEN),
 	INFO(SimpleColor.BRIGHT_BLUE),
-	DEBUG(SimpleColor.BRIGHT_GREEN);
+	WARNING(SimpleColor.BRIGHT_YELLOW),
+	ERROR(SimpleColor.BRIGHT_RED);
 
 	public final @NotNull Color color;
 


### PR DESCRIPTION
Reversed order of enum members for `ErrorLevel.isAtMinimum` to make it function correctly
Changed logic for `ErrorContainerImpl.errorIsMinimumLevel`

TODO:
- is `ErrorContainerImpl.checkValidMinimums` correct? Check logic.
- repeat `boolean isDisplayError` arguments in `ErrorContainerImpl`?
  Is it the best way to handle both display and exit errors?